### PR TITLE
Dependabot groups for development dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,6 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: 'npm'
+    groups:
+      development-dependencies:
+        dependency-type: 'development'


### PR DESCRIPTION
New [feature released](https://github.blog/changelog/2023-08-24-grouped-version-updates-for-dependabot-are-generally-available/), and here's the [docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)